### PR TITLE
Able to use crowdin-api and crowdin-cli through proxy.

### DIFF
--- a/lib/crowdin-api.rb
+++ b/lib/crowdin-api.rb
@@ -64,6 +64,7 @@ module Crowdin
         :json                   => true
       }.merge(options[:params])
 
+      RestClient.proxy = ENV['http_proxy']
       @connection = RestClient::Resource.new(@base_url, options)
     end
 


### PR DESCRIPTION
I had trouble using the crowdin-cli tool through a http proxy. Crowdin-cli depends on crowdin-api which in turn uses RestClient. To use RestClient through a http proxy the line

RestClient.proxy = ENV['http_proxy'] 

has to be added to crowdin-api.rb.
