### PR TITLE
Use HTTPS to connect to crowdin.com

### DIFF
--- a/lib/crowdin-api.rb
+++ b/lib/crowdin-api.rb
@@ -38,7 +38,7 @@ module Crowdin
       @api_key     = options.delete(:api_key)
       @project_id  = options.delete(:project_id)
       @account_key = options.delete(:account_key)
-      @base_url    = options.delete(:base_url) || 'http://api.crowdin.com'
+      @base_url    = options.delete(:base_url) || 'https://api.crowdin.com'
 
       @log = nil
 


### PR DESCRIPTION
When doing

``` ruby
crowdin = Crowdin::API.new project_id: 'openproject', api_key: '[secret]'
crowdin.project_info
```

I get an error:

```
crowdin.project_info
JSON::ParserError: 795: unexpected token at '<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
'
from /home/tessi/.rbenv/versions/2.1.1/lib/ruby/2.1.0/json/common.rb:155:in `parse'
```

Changing the `base_url` to HTTPS works (and is more secure \o/)
