### PR TITLE
Make query params required and raise corresponding error

### DIFF
--- a/lib/crowdin-api/api_resources/bundles.rb
+++ b/lib/crowdin-api/api_resources/bundles.rb
@@ -17,6 +17,10 @@ module Crowdin
 
       def add_bundle(query = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
+        %i(name format sourcePatterns exportPattern).each do |param|
+          query[param] || raise_parameter_is_required_error(param)
+        end
+
 
         request = Web::Request.new(
           connection,

--- a/lib/crowdin-api/api_resources/bundles.rb
+++ b/lib/crowdin-api/api_resources/bundles.rb
@@ -17,10 +17,9 @@ module Crowdin
 
       def add_bundle(query = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
-        %i(name format sourcePatterns exportPattern).each do |param|
+        %i[name format sourcePatterns exportPattern].each do |param|
           query[param] || raise_parameter_is_required_error(param)
         end
-
 
         request = Web::Request.new(
           connection,

--- a/spec/api_resources/bundles_spec.rb
+++ b/spec/api_resources/bundles_spec.rb
@@ -13,7 +13,7 @@ describe Crowdin::ApiResources::Bundles do
     describe '#add_bundle' do
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/bundles")
-        add_bundle = @crowdin.add_bundle({}, project_id)
+        add_bundle = @crowdin.add_bundle({ name: '', format: '', sourcePatterns: [], exportPattern: '' }, project_id)
         expect(add_bundle).to eq(200)
       end
     end


### PR DESCRIPTION
Changes:
- Added code to raise error for all the four required parameters -  `name` `format` `sourcePatterns` `exportPattern`

Please let me know if we need tests for these. I wasn't able to find tests for error flow paths, so didn't add them
