### PR TITLE
Glossaries API updates

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -104,7 +104,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 196
+  Max: 256
 
 # Offense count: 2
 # Configuration parameters: Max, CountKeywordArgs.

--- a/lib/crowdin-api/api_resources/glossaries.rb
+++ b/lib/crowdin-api/api_resources/glossaries.rb
@@ -194,6 +194,55 @@ module Crowdin
         )
         Web::SendRequest.new(request).perform
       end
+
+      def list_concepts(glossary_id = nil, query = {})
+        glossary_id || raise_parameter_is_required_error(:glossary_id)
+
+        request = Web::Request.new(
+          connection,
+          :get,
+          "#{config.target_api_url}/glossaries/#{glossary_id}/concepts",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+      def get_concept(glossary_id = nil, concept_id = nil)
+        glossary_id || raise_parameter_is_required_error(:glossary_id)
+        concept_id || raise_parameter_is_required_error(:concept_id)
+
+        request = Web::Request.new(
+          connection,
+          :get,
+          "#{config.target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}"
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+      def update_concept(glossary_id = nil, concept_id = nil, query = {})
+        glossary_id || raise_parameter_is_required_error(:glossary_id)
+        concept_id || raise_parameter_is_required_error(:concept_id)
+
+        request = Web::Request.new(
+          connection,
+          :put,
+          "#{config.target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+      def delete_concept(glossary_id = nil, concept_id = nil)
+        glossary_id || raise_parameter_is_required_error(:glossary_id)
+        concept_id || raise_parameter_is_required_error(:concept_id)
+
+        request = Web::Request.new(
+          connection,
+          :delete,
+          "#{config.target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}"
+        )
+        Web::SendRequest.new(request).perform
+      end
     end
   end
 end

--- a/spec/api_resources/glossaries_spec.rb
+++ b/spec/api_resources/glossaries_spec.rb
@@ -163,5 +163,48 @@ describe Crowdin::ApiResources::Glossaries do
         expect(edit_term).to eq(200)
       end
     end
+
+    describe '#list_concepts' do
+      let(:glossary_id) { 1 }
+
+      it 'when request are valid', :default do
+        stub_request(:get, "https://api.crowdin.com/#{target_api_url}/glossaries/#{glossary_id}/concepts")
+        concepts = @crowdin.list_concepts(glossary_id)
+        expect(concepts).to eq(200)
+      end
+    end
+
+    describe '#get_concept' do
+      let(:glossary_id) { 1 }
+      let(:concept_id) { 1 }
+
+      it 'when request are valid', :default do
+        stub_request(:get, "https://api.crowdin.com/#{target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}")
+        concept = @crowdin.get_concept(glossary_id, concept_id)
+        expect(concept).to eq(200)
+      end
+    end
+
+    describe '#update_concept' do
+      let(:glossary_id) { 1 }
+      let(:concept_id) { 1 }
+
+      it 'when request are valid', :default do
+        stub_request(:put, "https://api.crowdin.com/#{target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}")
+        concept = @crowdin.update_concept(glossary_id, concept_id)
+        expect(concept).to eq(200)
+      end
+    end
+
+    describe '#update_concept' do
+      let(:glossary_id) { 1 }
+      let(:concept_id) { 1 }
+
+      it 'when request are valid', :default do
+        stub_request(:delete, "https://api.crowdin.com/#{target_api_url}/glossaries/#{glossary_id}/concepts/#{concept_id}")
+        concept = @crowdin.delete_concept(glossary_id, concept_id)
+        expect(concept).to eq(200)
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes made in this PR: 
- Added support for Concept APIs
- Added relevant spec cases
- Changed rubocop offence rule for Metrics/ModuleLength to 256

Addresses issue #26 