### PR TITLE
Check method name passed to fetch_all to process

### DIFF
--- a/lib/crowdin-api/client/client.rb
+++ b/lib/crowdin-api/client/client.rb
@@ -103,7 +103,7 @@ module Crowdin
     # otherwise system will retry so many times, as indicated at tries_count
     #
     def fetch_all(api_resource, opts = {}, retry_opts = {})
-      unless Web::FetchAllExtensions::API_RESOURCES_FOR_FETCH_ALL.include?(api_resource)
+      unless api_resource.to_s.start_with?('list_')
         raise(Errors::FetchAllProcessingError, "#{api_resource} method aren't supported for FetchAll")
       end
 

--- a/lib/crowdin-api/core/fetch_all_extensions.rb
+++ b/lib/crowdin-api/core/fetch_all_extensions.rb
@@ -4,11 +4,6 @@ module Crowdin
   module Web
     module FetchAllExtensions
       MAX_ITEMS_COUNT_PER_REQUEST = 500.freeze
-      API_RESOURCES_FOR_FETCH_ALL = %i[list_vendors list_dictionaries list_directories list_distributions
-                                       list_workflow_templates list_languages list_labels list_mts list_files
-                                       list_projects list_groups list_branches list_strings list_storages
-                                       list_string_comments list_tasks list_user_tasks list_webhooks
-                                       list_terms list_file_revisions list_bundles].freeze
     end
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -82,4 +82,10 @@ describe 'Crowdin Client' do
       expect(@crowdin.config.base_url).to eq("https://#{full_organization_domain}")
     end
   end
+
+  describe 'Crowdin Client fetch_all' do
+    it 'should raise error if fetch_all is called for unsupported methods' do
+      expect { @crowdin.fetch_all(:add_bundle).to raise_error(Crowdin::Errors::FetchAllProcessingError) }
+    end
+  end
 end


### PR DESCRIPTION
- removed API_RESOURCES_FOR_FETCH_ALL constant
- checked for method passed to begin with `list_`
- spec case that tests the flow

Addresses #31 