### PR TITLE
feat: Added Support for Notification API

### DIFF
--- a/lib/crowdin-api.rb
+++ b/lib/crowdin-api.rb
@@ -5,7 +5,7 @@ module Crowdin
   API_RESOURCES_MODULES = %i[Storages Languages Projects Workflows SourceFiles Translations SourceStrings
                              StringTranslations StringComments Screenshots Glossaries TranslationMemory
                              MachineTranslationEngines Reports Tasks Users Teams Vendors Webhooks
-                             Dictionaries Distributions Labels TranslationStatus Bundles].freeze
+                             Dictionaries Distributions Labels TranslationStatus Bundles Notifications].freeze
 
   # Error Raisers modules
   ERROR_RAISERS_MODULES = %i[ApiErrorsRaiser ClientErrorsRaiser].freeze

--- a/lib/crowdin-api/api_resources/notifications.rb
+++ b/lib/crowdin-api/api_resources/notifications.rb
@@ -17,7 +17,7 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def send_notification_to_organization_member(query = {})
+      def send_notification_to_organization_members(query = {})
         enterprise_mode? || raise_only_for_enterprise_mode_error
 
         %i[message].each do |param|
@@ -33,7 +33,7 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def send_notifications_to_project_members(project_id = nil, query = {})
+      def send_notifications_to_project_members(query = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
 
         %i[message].each do |param|

--- a/lib/crowdin-api/api_resources/notifications.rb
+++ b/lib/crowdin-api/api_resources/notifications.rb
@@ -1,7 +1,23 @@
 module Crowdin
   module ApiResources
     module Notifications
+
+      def send_notification_to_authenticated_user(query = {})
+
+        %i[message].each do |param|
+          query[param] || raise_parameter_is_required_error(param)
+        end
+
+        request = Web::Request.new(
+          connection,
+          :post,
+          "#{config.target_api_url}/notify",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
       def send_notification_to_organization_member(query = {})
+        enterprise_mode? || raise_only_for_enterprise_mode_error
 
         %i[message].each do |param|
           query[param] || raise_parameter_is_required_error(param)

--- a/lib/crowdin-api/api_resources/notifications.rb
+++ b/lib/crowdin-api/api_resources/notifications.rb
@@ -1,0 +1,37 @@
+module Crowdin
+  module ApiResources
+    module Notifications
+      def send_notification_to_organization_member(query = {})
+
+        %i[message].each do |param|
+          query[param] || raise_parameter_is_required_error(param)
+        end
+
+        request = Web::Request.new(
+          connection,
+          :post,
+          "#{config.target_api_url}/notify",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+      def send_notifications_to_project_members(project_id = nil, query = {})
+        project_id || raise_project_id_is_required_error
+
+        %i[message].each do |param|
+          query[param] || raise_parameter_is_required_error(param)
+        end
+
+        request = Web::Request.new(
+          connection,
+          :post,
+          "#{config.target_api_url}/projects/#{project_id}/notify",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+    end
+  end
+end

--- a/lib/crowdin-api/api_resources/notifications.rb
+++ b/lib/crowdin-api/api_resources/notifications.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 module Crowdin
   module ApiResources
     module Notifications
-
       def send_notification_to_authenticated_user(query = {})
-
         %i[message].each do |param|
           query[param] || raise_parameter_is_required_error(param)
         end
@@ -48,7 +48,6 @@ module Crowdin
         )
         Web::SendRequest.new(request).perform
       end
-
     end
   end
 end

--- a/lib/crowdin-api/api_resources/notifications.rb
+++ b/lib/crowdin-api/api_resources/notifications.rb
@@ -16,6 +16,7 @@ module Crowdin
         )
         Web::SendRequest.new(request).perform
       end
+
       def send_notification_to_organization_member(query = {})
         enterprise_mode? || raise_only_for_enterprise_mode_error
 

--- a/spec/api_resources/notifications_spec.rb
+++ b/spec/api_resources/notifications_spec.rb
@@ -1,0 +1,53 @@
+describe Crowdin::ApiResources::Notifications do
+  describe 'Default endpoints' do
+    describe '#send_notification_to_organization_member' do
+      let(:body) do
+        { "message" => "New notification message" }
+      end
+
+      it 'when request are valid', :default do
+        stub_request(:post, "https://api.crowdin.com/#{target_api_url}/notify")
+          .with(body: { "message" => "New notification message" })
+        query =  { message: "New notification message" }
+        add_project = @crowdin.send_notification_to_organization_member(query)
+        expect(add_project).to eq(200)
+      end
+
+      it 'raises ArgumentError when request is missing required query parameter', :default do
+        expect do
+          @crowdin.send_notification_to_organization_member({})
+        end.to raise_error(ArgumentError, ':message is required')
+      end
+
+    end
+
+    describe '#send_notification_to_organization_member' do
+      let(:project_id) { 1 }
+      let(:body) do
+        { "message" => "New notification message" }
+      end
+
+      it 'when request are valid', :default do
+        stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/notify")
+          .with(body: { "message" => "New notification message" })
+        query =  { message: "New notification message" }
+        add_project = @crowdin.send_notifications_to_project_members(project_id, query)
+        expect(add_project).to eq(200)
+      end
+
+      it 'raises ArgumentError when request is missing required query parameter', :default do
+        expect do
+          @crowdin.send_notifications_to_project_members(project_id, {})
+        end.to raise_error(ArgumentError, ':message is required')
+      end
+
+      it 'raises ArgumentError when request is missing required query parameter', :default do
+        query =  { message: "New notification message" }
+        expect do
+          @crowdin.send_notifications_to_project_members(nil, query)
+        end.to raise_error(ArgumentError, ':project_id is required in parameters or while Client initialization')
+      end
+
+    end
+  end
+end

--- a/spec/api_resources/notifications_spec.rb
+++ b/spec/api_resources/notifications_spec.rb
@@ -41,7 +41,7 @@ describe Crowdin::ApiResources::Notifications do
         end.to raise_error(ArgumentError, ':message is required')
       end
 
-      it 'raises ArgumentError when request is missing required query parameter', :default do
+      it 'raises ArgumentError when request is missing project_id parameter', :default do
         query =  { message: "New notification message" }
         expect do
           @crowdin.send_notifications_to_project_members(nil, query)

--- a/spec/api_resources/notifications_spec.rb
+++ b/spec/api_resources/notifications_spec.rb
@@ -7,8 +7,8 @@ describe Crowdin::ApiResources::Notifications do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/notify")
           .with(body: { 'message' => 'New notification message' })
         query = { message: 'New notification message' }
-        add_project = @crowdin.send_notification_to_authenticated_user(query)
-        expect(add_project).to eq(200)
+        response = @crowdin.send_notification_to_authenticated_user(query)
+        expect(response).to eq(200)
       end
 
       it 'raises ArgumentError when request is missing required query parameter', :default do
@@ -18,45 +18,45 @@ describe Crowdin::ApiResources::Notifications do
       end
     end
 
-    describe '#send_notification_to_organization_member' do
+    describe '#send_notifications_to_project_members' do
       let(:project_id) { 1 }
 
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/notify")
           .with(body: { 'message' => 'New notification message' })
         query = { message: 'New notification message' }
-        add_project = @crowdin.send_notifications_to_project_members(project_id, query)
-        expect(add_project).to eq(200)
+        response = @crowdin.send_notifications_to_project_members(query, project_id)
+        expect(response).to eq(200)
       end
 
       it 'raises ArgumentError when request is missing required query parameter', :default do
         expect do
-          @crowdin.send_notifications_to_project_members(project_id, {})
+          @crowdin.send_notifications_to_project_members({}, project_id)
         end.to raise_error(ArgumentError, ':message is required')
       end
 
       it 'raises ArgumentError when request is missing project_id parameter', :default do
         query =  { message: 'New notification message' }
         expect do
-          @crowdin.send_notifications_to_project_members(nil, query)
+          @crowdin.send_notifications_to_project_members(query, nil)
         end.to raise_error(ArgumentError, ':project_id is required in parameters or while Client initialization')
       end
     end
   end
 
   describe 'Enterprise endpoints' do
-    describe '#send_notification_to_organization_member' do
+    describe '#send_notification_to_organization_members' do
       it 'when request are valid', :enterprise do
         stub_request(:post, "https://domain.api.crowdin.com/#{target_api_url}/notify")
           .with(body: { 'message' => 'New notification message' })
         query = { message: 'New notification message' }
-        add_project = @crowdin.send_notification_to_organization_member(query)
-        expect(add_project).to eq(200)
+        response = @crowdin.send_notification_to_organization_members(query)
+        expect(response).to eq(200)
       end
 
       it 'raises ArgumentError when request is missing required query parameter', :enterprise do
         expect do
-          @crowdin.send_notification_to_organization_member({})
+          @crowdin.send_notification_to_organization_members({})
         end.to raise_error(ArgumentError, ':message is required')
       end
     end

--- a/spec/api_resources/notifications_spec.rb
+++ b/spec/api_resources/notifications_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 describe Crowdin::ApiResources::Notifications do
   describe 'Default endpoints' do
     describe '#send_notification_to_authenticated_user' do
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/notify")
-          .with(body: { "message" => "New notification message" })
-        query =  { message: "New notification message" }
+          .with(body: { 'message' => 'New notification message' })
+        query = { message: 'New notification message' }
         add_project = @crowdin.send_notification_to_authenticated_user(query)
         expect(add_project).to eq(200)
       end
@@ -14,7 +16,6 @@ describe Crowdin::ApiResources::Notifications do
           @crowdin.send_notification_to_authenticated_user({})
         end.to raise_error(ArgumentError, ':message is required')
       end
-
     end
 
     describe '#send_notification_to_organization_member' do
@@ -22,8 +23,8 @@ describe Crowdin::ApiResources::Notifications do
 
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/notify")
-          .with(body: { "message" => "New notification message" })
-        query =  { message: "New notification message" }
+          .with(body: { 'message' => 'New notification message' })
+        query = { message: 'New notification message' }
         add_project = @crowdin.send_notifications_to_project_members(project_id, query)
         expect(add_project).to eq(200)
       end
@@ -35,12 +36,11 @@ describe Crowdin::ApiResources::Notifications do
       end
 
       it 'raises ArgumentError when request is missing project_id parameter', :default do
-        query =  { message: "New notification message" }
+        query =  { message: 'New notification message' }
         expect do
           @crowdin.send_notifications_to_project_members(nil, query)
         end.to raise_error(ArgumentError, ':project_id is required in parameters or while Client initialization')
       end
-
     end
   end
 
@@ -48,8 +48,8 @@ describe Crowdin::ApiResources::Notifications do
     describe '#send_notification_to_organization_member' do
       it 'when request are valid', :enterprise do
         stub_request(:post, "https://domain.api.crowdin.com/#{target_api_url}/notify")
-          .with(body: { "message" => "New notification message" })
-        query =  { message: "New notification message" }
+          .with(body: { 'message' => 'New notification message' })
+        query = { message: 'New notification message' }
         add_project = @crowdin.send_notification_to_organization_member(query)
         expect(add_project).to eq(200)
       end
@@ -59,7 +59,6 @@ describe Crowdin::ApiResources::Notifications do
           @crowdin.send_notification_to_organization_member({})
         end.to raise_error(ArgumentError, ':message is required')
       end
-
     end
   end
 end

--- a/spec/api_resources/notifications_spec.rb
+++ b/spec/api_resources/notifications_spec.rb
@@ -1,21 +1,17 @@
 describe Crowdin::ApiResources::Notifications do
   describe 'Default endpoints' do
-    describe '#send_notification_to_organization_member' do
-      let(:body) do
-        { "message" => "New notification message" }
-      end
-
+    describe '#send_notification_to_authenticated_user' do
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/notify")
           .with(body: { "message" => "New notification message" })
         query =  { message: "New notification message" }
-        add_project = @crowdin.send_notification_to_organization_member(query)
+        add_project = @crowdin.send_notification_to_authenticated_user(query)
         expect(add_project).to eq(200)
       end
 
       it 'raises ArgumentError when request is missing required query parameter', :default do
         expect do
-          @crowdin.send_notification_to_organization_member({})
+          @crowdin.send_notification_to_authenticated_user({})
         end.to raise_error(ArgumentError, ':message is required')
       end
 
@@ -23,9 +19,6 @@ describe Crowdin::ApiResources::Notifications do
 
     describe '#send_notification_to_organization_member' do
       let(:project_id) { 1 }
-      let(:body) do
-        { "message" => "New notification message" }
-      end
 
       it 'when request are valid', :default do
         stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/notify")
@@ -46,6 +39,25 @@ describe Crowdin::ApiResources::Notifications do
         expect do
           @crowdin.send_notifications_to_project_members(nil, query)
         end.to raise_error(ArgumentError, ':project_id is required in parameters or while Client initialization')
+      end
+
+    end
+  end
+
+  describe 'Enterprise endpoints' do
+    describe '#send_notification_to_organization_member' do
+      it 'when request are valid', :enterprise do
+        stub_request(:post, "https://domain.api.crowdin.com/#{target_api_url}/notify")
+          .with(body: { "message" => "New notification message" })
+        query =  { message: "New notification message" }
+        add_project = @crowdin.send_notification_to_organization_member(query)
+        expect(add_project).to eq(200)
+      end
+
+      it 'raises ArgumentError when request is missing required query parameter', :enterprise do
+        expect do
+          @crowdin.send_notification_to_organization_member({})
+        end.to raise_error(ArgumentError, ':message is required')
       end
 
     end


### PR DESCRIPTION
Addresses #50 .  Added Support for the following APIs

- Send Notification to Authenticated User (crowdin.com)
- Send Notification To Project Members (crowdin.com and Crowdin Enterprise)
- Send Notification To Organization Members (Crowdin Enterprise)