### PR TITLE
feat: Return the full API response if the `destination` param is not passed

### DIFF
--- a/lib/crowdin-api/core/send_request.rb
+++ b/lib/crowdin-api/core/send_request.rb
@@ -44,7 +44,7 @@ module Crowdin
         end
 
         def fetch_response_data(doc)
-          if doc['data'].is_a?(Hash) && doc['data']['url'] && doc['data']['url'].include?('response-content-disposition')
+          if @file_destination && doc['data'].is_a?(Hash) && doc['data']['url']
             download_file(doc['data']['url'])
           else
             doc
@@ -53,8 +53,7 @@ module Crowdin
 
         def download_file(url)
           download    = URI.parse(url).open
-          destination = @file_destination || download.meta['content-disposition']
-                                                     .match(/filename=("?)(.+)\1/)[2]
+          destination = @file_destination
 
           IO.copy_stream(download, destination)
 


### PR DESCRIPTION
Issue: #66
Reference: https://github.com/crowdin/crowdin-api-client-ruby/pull/68#issuecomment-1923457923