### PR TITLE
fix(bundles): add destination parameter

### DIFF
--- a/lib/crowdin-api/api_resources/bundles.rb
+++ b/lib/crowdin-api/api_resources/bundles.rb
@@ -70,9 +70,10 @@ module Crowdin
 
       # @param bundle_id [Integer] Bundle ID
       # @param export_id [String] Export ID
+      # @param destination [String] Destination of File
       # * {https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.exports.download.get  API Documentation}
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.bundles.exports.download.get  Enterprise API Documentation}
-      def download_bundle(bundle_id, export_id, project_id = config.project_id)
+      def download_bundle(bundle_id, export_id, destination = nil, project_id = config.project_id)
         bundle_id  || raise_parameter_is_required_error(:bundle_id)
         export_id  || raise_parameter_is_required_error(:export_id)
         project_id || raise_project_id_is_required_error
@@ -82,7 +83,7 @@ module Crowdin
           :get,
           "#{config.target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports/#{export_id}/download"
         )
-        Web::SendRequest.new(request).perform
+        Web::SendRequest.new(request, destination).perform
       end
 
       # @param bundle_id [Integer] Bundle ID

--- a/spec/api_resources/bundles_spec.rb
+++ b/spec/api_resources/bundles_spec.rb
@@ -44,7 +44,7 @@ describe Crowdin::ApiResources::Bundles do
 
       it 'when request are valid', :default do
         stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports/#{export_id}/download")
-        download_bundle = @crowdin.download_bundle(bundle_id, export_id, project_id)
+        download_bundle = @crowdin.download_bundle(bundle_id, export_id, nil, project_id)
         expect(download_bundle).to eq(200)
       end
     end


### PR DESCRIPTION
Add the missing destination parameter to the download_bundle method.

Due to the changes made in the 1.8.0 release for the download methods. Related discussion - https://github.com/crowdin/crowdin-api-client-ruby/issues/66 and PR - https://github.com/crowdin/crowdin-api-client-ruby/pull/69.

Because of those changes the download_bundle method also needs the destination parameter now. Source discussion of the change https://github.com/crowdin/crowdin-api-client-ruby/issues/83