### PR TITLE
feat: Add support for Task Comments API endpoints

### DIFF
--- a/lib/crowdin-api/api_resources/tasks.rb
+++ b/lib/crowdin-api/api_resources/tasks.rb
@@ -98,7 +98,9 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def list_task_comments(project_id = config.project_id, task_id = nil, query = {})
+      # * {https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.getMany  API Documentation}
+      # * {https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.getMany  Enterprise API Documentation}
+      def list_task_comments(task_id = nil, query = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
         task_id    || raise_parameter_is_required_error(:task_id)
 
@@ -111,7 +113,9 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def get_task_comment(project_id = config.project_id, task_id = nil, comment_id = nil)
+      # * {https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.get  API Documentation}
+      # * {https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.get  Enterprise API Documentation}
+      def get_task_comment(task_id = nil, comment_id = nil, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
         task_id    || raise_parameter_is_required_error(:task_id)
         comment_id || raise_parameter_is_required_error(:comment_id)
@@ -124,7 +128,9 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def add_task_comment(project_id = config.project_id, task_id = nil, body = {})
+      # * {https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.post  API Documentation}
+      # * {https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.post  Enterprise API Documentation}
+      def add_task_comment(task_id = nil, body = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
         task_id    || raise_parameter_is_required_error(:task_id)
 
@@ -137,7 +143,9 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
-      def edit_task_comment(project_id = config.project_id, task_id = nil, comment_id = nil, body = [])
+      # * {https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.patch  API Documentation}
+      # * {https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.patch  Enterprise API Documentation}
+      def edit_task_comment(task_id = nil, comment_id = nil, body = {}, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
         task_id    || raise_parameter_is_required_error(:task_id)
         comment_id || raise_parameter_is_required_error(:comment_id)
@@ -148,11 +156,12 @@ module Crowdin
           "#{config.target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}",
           { params: body }
         )
-
         Web::SendRequest.new(request).perform
       end
 
-      def delete_task_comment(project_id = config.project_id, task_id = nil, comment_id = nil)
+      # * {https://support.crowdin.com/developer/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.delete  API Documentation}
+      # * {https://support.crowdin.com/developer/enterprise/api/v2/#tag/Tasks/operation/api.projects.tasks.comments.delete  Enterprise API Documentation}
+      def delete_task_comment(task_id = nil, comment_id = nil, project_id = config.project_id)
         project_id || raise_project_id_is_required_error
         task_id    || raise_parameter_is_required_error(:task_id)
         comment_id || raise_parameter_is_required_error(:comment_id)

--- a/spec/api_resources/tasks_spec.rb
+++ b/spec/api_resources/tasks_spec.rb
@@ -76,49 +76,49 @@ describe Crowdin::ApiResources::Tasks do
       end
     end
   end
-end
 
-describe 'Task Comments endpoints' do
-  let(:task_id) { 1 }
-  let(:comment_id) { 101 }
+  describe 'Task Comments endpoints' do
+    let(:task_id) { 1 }
+    let(:comment_id) { 101 }
 
-  describe '#list_task_comments' do
-    it 'when request is valid', :default do
-      stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments")
-      list_task_comments = @crowdin.list_task_comments(project_id, task_id, {})
-      expect(list_task_comments).to eq(200)
+    describe '#list_task_comments' do
+      it 'when request is valid', :default do
+        stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments")
+        list_task_comments = @crowdin.list_task_comments(task_id, {}, project_id)
+        expect(list_task_comments).to eq(200)
+      end
     end
-  end
 
-  describe '#get_task_comment' do
-    it 'when request is valid', :default do
-      stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
-      get_task_comment = @crowdin.get_task_comment(project_id, task_id, comment_id)
-      expect(get_task_comment).to eq(200)
+    describe '#get_task_comment' do
+      it 'when request is valid', :default do
+        stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
+        get_task_comment = @crowdin.get_task_comment(task_id, comment_id, project_id)
+        expect(get_task_comment).to eq(200)
+      end
     end
-  end
 
-  describe '#add_task_comment' do
-    it 'when request is valid', :default do
-      stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments")
-      add_task_comment = @crowdin.add_task_comment(project_id, task_id, { text: 'New comment' })
-      expect(add_task_comment).to eq(200)
+    describe '#add_task_comment' do
+      it 'when request is valid', :default do
+        stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments")
+        add_task_comment = @crowdin.add_task_comment(task_id, { text: 'New comment' }, project_id)
+        expect(add_task_comment).to eq(200)
+      end
     end
-  end
 
-  describe '#edit_task_comment' do
-    it 'when request is valid', :default do
-      stub_request(:patch, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
-      edit_task_comment = @crowdin.edit_task_comment(project_id, task_id, comment_id, { text: 'Updated comment' })
-      expect(edit_task_comment).to eq(200)
+    describe '#edit_task_comment' do
+      it 'when request is valid', :default do
+        stub_request(:patch, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
+        edit_task_comment = @crowdin.edit_task_comment(task_id, comment_id, { text: 'Updated comment' }, project_id)
+        expect(edit_task_comment).to eq(200)
+      end
     end
-  end
 
-  describe '#delete_task_comment' do
-    it 'when request is valid', :default do
-      stub_request(:delete, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
-      delete_task_comment = @crowdin.delete_task_comment(project_id, task_id, comment_id)
-      expect(delete_task_comment).to eq(200)
+    describe '#delete_task_comment' do
+      it 'when request is valid', :default do
+        stub_request(:delete, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/tasks/#{task_id}/comments/#{comment_id}")
+        delete_task_comment = @crowdin.delete_task_comment(task_id, comment_id, project_id)
+        expect(delete_task_comment).to eq(200)
+      end
     end
   end
 end


### PR DESCRIPTION
Add support for Task Comments API endpoints

## **Description**
This PR adds support for the new **Task Comments API** in the Crowdin Ruby client library. The following endpoints have been implemented and tested:

- **List Task Comments** (`list_task_comments`)
- **Get Task Comment** (`get_task_comment`)
- **Add Task Comment** (`add_task_comment`)
- **Edit Task Comment** (`edit_task_comment`)
- **Delete Task Comment** (`delete_task_comment`)

All endpoints include corresponding **RSpec tests** in `spec/api_resources/tasks_spec.rb` to ensure proper functionality.

## **Changes Include**
- Updated `lib/crowdin-api/api_resources/tasks.rb` with methods for the new endpoints.
- Added tests in `spec/api_resources/tasks_spec.rb` for:
  - [x] Listing comments
  - [x] Adding a comment
  - [x] Retrieving a comment
  - [x] Editing a comment
  - [x] Deleting a comment

## **Related Issue**
This PR closes [#108](https://github.com/crowdin/crowdin-api-client-ruby/issues/108).

## **Testing**
- [x] Verified each method with RSpec tests
- [x] Manual verification in IRB
- [x] All tests pass successfully


