### PR TITLE
fix: incorrect parameter validation for 'path'

### DIFF
--- a/lib/crowdin-api/api_resources/applications.rb
+++ b/lib/crowdin-api/api_resources/applications.rb
@@ -7,7 +7,7 @@ module Crowdin
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.applications.api.get  API Documentation}
       def get_application_data(application_identifier = nil, path = nil)
         application_identifier || raise_parameter_is_required_error(:application_identifier)
-        application_identifier || raise_parameter_is_required_error(:path)
+        path || raise_parameter_is_required_error(:path)
 
         request = Web::Request.new(
           connection,
@@ -21,7 +21,7 @@ module Crowdin
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.applications.api.put  API Documentation}
       def update_or_restore_application_data(query = {}, application_identifier = nil, path = nil)
         application_identifier || raise_parameter_is_required_error(:application_identifier)
-        application_identifier || raise_parameter_is_required_error(:path)
+        path || raise_parameter_is_required_error(:path)
 
         request = Web::Request.new(
           connection,
@@ -36,7 +36,7 @@ module Crowdin
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.applications.api.put  API Documentation}
       def add_application_data(query = {}, application_identifier = nil, path = nil)
         application_identifier || raise_parameter_is_required_error(:application_identifier)
-        application_identifier || raise_parameter_is_required_error(:path)
+        path || raise_parameter_is_required_error(:path)
 
         request = Web::Request.new(
           connection,
@@ -51,7 +51,7 @@ module Crowdin
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.applications.api.delete  API Documentation}
       def delete_application_data(query = {}, application_identifier = nil, path = nil)
         application_identifier || raise_parameter_is_required_error(:application_identifier)
-        application_identifier || raise_parameter_is_required_error(:path)
+        path || raise_parameter_is_required_error(:path)
 
         request = Web::Request.new(
           connection,
@@ -66,7 +66,7 @@ module Crowdin
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.applications.api.patch  API Documentation}
       def edit_application_data(query = {}, application_identifier = nil, path = nil)
         application_identifier || raise_parameter_is_required_error(:application_identifier)
-        application_identifier || raise_parameter_is_required_error(:path)
+        path || raise_parameter_is_required_error(:path)
 
         request = Web::Request.new(
           connection,


### PR DESCRIPTION
The methods in `Applications` module were incorrectly validating the `path` parameter by checking if `application_identifier` was nil instead of checking if `path` itself was nil. This allowed a nil `path` to pass through, leading to invalid URL construction.

This PR fixes the validation logic across all application data methods (`get`, `update_or_restore`, `add`, `delete`, and `edit`) to correctly validate the presence of the `path` parameter.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.