### PR TITLE
feat: add GraphQL endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ file_revisions = crowdin.list_file_revisions(your_file_id, { limit: 10 }, your_p
 
 ### GraphQL API
 
-The client can send GraphQL requests to Crowdin Enterprise.
+The client can send GraphQL requests to Crowdin's default API host or to an Enterprise organization endpoint.
 
 ```ruby
 query = <<~GRAPHQL
@@ -153,7 +153,7 @@ response = crowdin.graphql({ query: query })
 You can also provide a custom endpoint URL for testing.
 
 ```ruby
-crowdin.graphql({ query: query }, { url: 'http://localhost:3000/api/graphql' })
+crowdin.graphql({ query: query }, url: 'http://localhost:3000/api/graphql')
 ```
 
 ### Fetch all records

--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ file_revisions = crowdin.list_file_revisions(your_file_id, { limit: 10 }, your_p
 # Note: more examples you can find in spec folder
 ```
 
+### GraphQL API
+
+The client can send GraphQL requests to Crowdin Enterprise.
+
+```ruby
+query = <<~GRAPHQL
+  query Viewer {
+    viewer {
+      id
+    }
+  }
+GRAPHQL
+
+response = crowdin.graphql({ query: query })
+```
+
+You can also provide a custom endpoint URL for testing.
+
+```ruby
+crowdin.graphql({ query: query }, { url: 'http://localhost:3000/api/graphql' })
+```
+
 ### Fetch all records
 
 There is a possibility to fetch all records from paginatable methods using `fetch_all` method.

--- a/lib/crowdin-api.rb
+++ b/lib/crowdin-api.rb
@@ -23,6 +23,7 @@ require 'crowdin-api/core/errors_raisers'
 require 'crowdin-api/core/request'
 require 'crowdin-api/core/send_request'
 require 'crowdin-api/core/fetch_all_extensions'
+require 'crowdin-api/core/graphql_extensions'
 
 # API modules
 Crowdin::API_RESOURCES_MODULES.each do |api_resource|

--- a/lib/crowdin-api/client/client.rb
+++ b/lib/crowdin-api/client/client.rb
@@ -31,6 +31,7 @@ module Crowdin
     end
 
     include Web::FetchAllExtensions
+    include Web::GraphqlExtensions
 
     # Config instance that includes configuration options for the Client
     attr_reader :config
@@ -67,20 +68,6 @@ module Crowdin
 
     def logger_enabled?
       config.logger_enabled?
-    end
-
-    def graphql(query = {}, request_options = {})
-      response = ::RestClient::Request.execute(
-        {
-          method: :post,
-          url: request_options[:url] || "#{config.base_url}/api/graphql",
-          payload: query.to_json
-        }.merge(options)
-      )
-
-      response.body.empty? ? response.code : JSON.parse(response.body)
-    rescue StandardError => e
-      e.message
     end
 
     #

--- a/lib/crowdin-api/client/client.rb
+++ b/lib/crowdin-api/client/client.rb
@@ -69,6 +69,20 @@ module Crowdin
       config.logger_enabled?
     end
 
+    def graphql(query = {}, request_options = {})
+      response = ::RestClient::Request.execute(
+        {
+          method: :post,
+          url: request_options[:url] || "#{config.base_url}/api/graphql",
+          payload: query.to_json
+        }.merge(options)
+      )
+
+      response.body.empty? ? response.code : JSON.parse(response.body)
+    rescue StandardError => e
+      e.message
+    end
+
     #
     # FetchAll options:
     # * limit, Integer, default: 500 | How many records need to load per one request

--- a/lib/crowdin-api/client/client.rb
+++ b/lib/crowdin-api/client/client.rb
@@ -33,14 +33,8 @@ module Crowdin
     include Web::FetchAllExtensions
     include Web::GraphqlExtensions
 
-    # Config instance that includes configuration options for the Client
-    attr_reader :config
-    # Instance with established connection through RestClient to the Crowdin API
-    attr_reader :connection
-    # Instance with options and headers for RestClient connection
-    attr_reader :options
-    # Logger instance
-    attr_reader :logger
+    # Client configuration, connection, request options, and logger instances
+    attr_reader :config, :connection, :options, :logger
 
     def initialize(&block)
       build_configuration(&block)

--- a/lib/crowdin-api/core/graphql_extensions.rb
+++ b/lib/crowdin-api/core/graphql_extensions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Crowdin
+  module Web
+    module GraphqlExtensions
+      def graphql(query = {}, request_options = {})
+        response = ::RestClient::Request.execute(
+          {
+            method: :post,
+            url: request_options[:url] || "#{config.base_url}/api/graphql",
+            payload: query.to_json
+          }.merge(options)
+        )
+
+        response.body.empty? ? response.code : JSON.parse(response.body)
+      rescue StandardError => e
+        e.message
+      end
+    end
+  end
+end

--- a/lib/crowdin-api/core/graphql_extensions.rb
+++ b/lib/crowdin-api/core/graphql_extensions.rb
@@ -3,11 +3,11 @@
 module Crowdin
   module Web
     module GraphqlExtensions
-      def graphql(query = {}, request_options = {})
+      def graphql(query = {}, url: nil)
         response = ::RestClient::Request.execute(
           {
             method: :post,
-            url: request_options[:url] || "#{config.base_url}/api/graphql",
+            url: url || "#{config.base_url}/api/graphql",
             payload: query.to_json
           }.merge(options)
         )

--- a/lib/crowdin-api/core/graphql_extensions.rb
+++ b/lib/crowdin-api/core/graphql_extensions.rb
@@ -3,18 +3,19 @@
 module Crowdin
   module Web
     module GraphqlExtensions
-      def graphql(query = {}, url: nil)
+      def graphql(query = nil, **request_options)
+        url = request_options.delete(:url)
+        graphql_query = query || request_options
+
         response = ::RestClient::Request.execute(
           {
             method: :post,
             url: url || "#{config.base_url}/api/graphql",
-            payload: query.to_json
+            payload: graphql_query.to_json
           }.merge(options)
-        )
+        ) { |res, _, _| res }
 
         response.body.empty? ? response.code : JSON.parse(response.body)
-      rescue StandardError => e
-        e.message
       end
     end
   end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -131,7 +131,7 @@ describe 'Crowdin Client' do
         .with(body: graphql_request.to_json)
         .to_return(body: graphql_response.to_json)
 
-      expect(@crowdin.graphql(graphql_request, { url: custom_url })).to eq(graphql_response)
+      expect(@crowdin.graphql(graphql_request, url: custom_url)).to eq(graphql_response)
     end
   end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -98,6 +98,43 @@ describe 'Crowdin Client' do
     end
   end
 
+  describe 'Crowdin Client graphql' do
+    let(:graphql_request) do
+      {
+        query: 'query Viewer { viewer { id } }',
+        operationName: 'Viewer',
+        variables: { projectId: 1, emptyValue: nil }
+      }
+    end
+    let(:graphql_response) { { 'data' => { 'viewer' => { 'id' => 1 } } } }
+
+    it 'posts to the default GraphQL endpoint', :default do
+      stub_request(:post, 'https://api.crowdin.com/api/graphql')
+        .with(body: graphql_request.to_json)
+        .to_return(body: graphql_response.to_json)
+
+      expect(@crowdin.graphql(graphql_request)).to eq(graphql_response)
+    end
+
+    it 'posts to the Enterprise GraphQL endpoint', :enterprise do
+      stub_request(:post, 'https://domain.api.crowdin.com/api/graphql')
+        .with(body: graphql_request.to_json)
+        .to_return(body: graphql_response.to_json)
+
+      expect(@crowdin.graphql(graphql_request)).to eq(graphql_response)
+    end
+
+    it 'supports a custom GraphQL endpoint URL', :default do
+      custom_url = 'http://localhost:3000/api/graphql'
+
+      stub_request(:post, custom_url)
+        .with(body: graphql_request.to_json)
+        .to_return(body: graphql_response.to_json)
+
+      expect(@crowdin.graphql(graphql_request, { url: custom_url })).to eq(graphql_response)
+    end
+  end
+
   describe 'connection' do
     subject(:connection) { crowdin_client.connection }
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -133,6 +133,16 @@ describe 'Crowdin Client' do
 
       expect(@crowdin.graphql(graphql_request, url: custom_url)).to eq(graphql_response)
     end
+
+    it 'returns parsed GraphQL error responses', :default do
+      graphql_error_response = { 'errors' => [{ 'message' => 'Invalid query' }] }
+
+      stub_request(:post, 'https://api.crowdin.com/api/graphql')
+        .with(body: graphql_request.to_json)
+        .to_return(status: 400, body: graphql_error_response.to_json)
+
+      expect(@crowdin.graphql(graphql_request)).to eq(graphql_error_response)
+    end
   end
 
   describe 'connection' do


### PR DESCRIPTION
## Summary

- Add `Crowdin::Client#graphql` for GraphQL POST requests to `/api/graphql`.
- Support Enterprise base URLs and a custom endpoint URL for tests/local GraphQL servers.
- Add unit coverage for default, Enterprise, and custom URL behavior, plus README usage.

Fixes #100.

## Validation

- `ruby -c lib/crowdin-api/client/client.rb` -> `Syntax OK`
- `ruby -c spec/unit/client_spec.rb` -> `Syntax OK`
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- `git diff origin/main..HEAD --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found
- Standalone Ruby smoke with `RestClient::Request.execute` stub verified default, Enterprise, custom URL, payload, and parsed response behavior -> `standalone graphql smoke passed`

Not run:

- `bundle exec rspec spec/unit/client_spec.rb` could not complete in this local macOS 12 environment. System Ruby bundle install fails building `unf_ext` because the CLT SDK has `universal-darwin22` Ruby headers while Ruby 2.6 Makefiles expect `universal-darwin21`; Homebrew portable Ruby 4.0.4 installs the bundle but hangs loading the bundled native `json` extension; `brew install ruby` and `brew install ruby@3.4` both attempted long LLVM/Rust source builds and were aborted.
